### PR TITLE
From the ES docs, this should be _all, not ?all

### DIFF
--- a/newrelic_plugin_agent/plugins/elasticsearch.py
+++ b/newrelic_plugin_agent/plugins/elasticsearch.py
@@ -18,7 +18,7 @@ class ElasticSearch(base.JSONStatsPlugin):
     GAUGE_MATCH = ['Current']
 
     DEFAULT_HOST = 'localhost'
-    DEFAULT_PATH = '/_nodes/stats?all'
+    DEFAULT_PATH = '/_nodes/stats/_all'
     DEFAULT_PORT = 9200
     GUID = 'com.meetme.newrelic_elasticsearch_node_agent'
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if sys.version_info < (2, 7, 0):
     install_requires.append('importlib')
 
 setup(name='newrelic_plugin_agent',
-      version='1.3.0',
+      version='1.3.1',
       description='Python based agent for collecting metrics for NewRelic',
       url='https://github.com/MeetMe/newrelic-plugin-agent',
       packages=['newrelic_plugin_agent', 'newrelic_plugin_agent.plugins'],


### PR DESCRIPTION
https://www.elastic.co/guide/en/elasticsearch/reference/5.1/cluster-nodes-stats.html

Checked against multiple versions of ES.